### PR TITLE
Add GitHub Skills activity

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -74,6 +74,12 @@ activities = {
         "schedule": "Fridays, 4:00 PM - 5:30 PM",
         "max_participants": 12,
         "participants": ["charlotte@mergington.edu", "henry@mergington.edu"]
+    },
+    "GitHub Skills": {
+        "description": "Learn practical coding and collaboration skills through GitHub. Part of the GitHub Certifications program to help with college applications.",
+        "schedule": "Wednesdays and Saturdays, 2:00 PM - 3:30 PM",
+        "max_participants": 25,
+        "participants": []
     }
 }
 


### PR DESCRIPTION
## Description
Adds the GitHub Skills activity that was announced in the school assembly but missing from the signup page.

## Changes
- Added "GitHub Skills" activity to the activities database
- Description mentions the GitHub partnership and Certifications program for college applications
- Schedule set to Wednesdays and Saturdays, 2:00 PM - 3:30 PM
- Capacity: 25 participants to accommodate student demand
- Activity is ready for immediate signups

## Resolves
Fixes #6 - 🚨 Missing Activity: GitHub Skills

## Testing
Students can now:
- View GitHub Skills in the activities list
- Sign up for the activity
- See the schedule and capacity